### PR TITLE
✨ Oauth2 카카오 회원가입 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,11 @@ dependencies {
 	runtimeOnly("mysql:mysql-connector-java")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("com.ninja-squad:springmockk:3.1.1")
+	implementation("org.springframework.boot:spring-boot-starter-security")
+	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
+	implementation("io.jsonwebtoken:jjwt-api:0.11.2")
+	runtimeOnly("io.jsonwebtoken:jjwt-impl:0.11.2")
+	runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.11.2")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/smu/som/common/config/ObjectMapperConfig.kt
+++ b/src/main/kotlin/com/smu/som/common/config/ObjectMapperConfig.kt
@@ -1,0 +1,13 @@
+package com.smu.som.common.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class ObjectMapperConfig {
+	@Bean
+	fun objectMapper(): ObjectMapper {
+		return ObjectMapper()
+	}
+}

--- a/src/main/kotlin/com/smu/som/common/config/RestTemplateConfig.kt
+++ b/src/main/kotlin/com/smu/som/common/config/RestTemplateConfig.kt
@@ -1,0 +1,13 @@
+package com.smu.som.common.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.client.RestTemplate
+
+@Configuration
+class RestTemplateConfig {
+	@Bean
+	fun restTemplate(): RestTemplate {
+		return RestTemplate()
+	}
+}

--- a/src/main/kotlin/com/smu/som/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/smu/som/common/config/SecurityConfig.kt
@@ -2,32 +2,40 @@ package com.smu.som.common.config
 
 import com.smu.som.common.jwt.filter.JwtAuthenticationFilter
 import com.smu.som.common.jwt.util.JwtResolver
+import org.springframework.context.annotation.Bean
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.builders.WebSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer
 import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @EnableWebSecurity
 class SecurityConfig(
-	private val jwtResolver: JwtResolver
-) : WebSecurityConfigurerAdapter() {
-	override fun configure(web: WebSecurity) {
-		web
-			.ignoring().antMatchers("/api/auth/**")
+	private val jwtResolver: JwtResolver)
+{
+	@Bean
+	fun webSecurityCustomizer(): WebSecurityCustomizer? {
+		return WebSecurityCustomizer {
+			web: WebSecurity -> web.ignoring().antMatchers("/api/auth/**")
+		}
 	}
 
-	override fun configure(http: HttpSecurity) {
-		http
+	@Bean
+	fun filterChain(http: HttpSecurity?): SecurityFilterChain {
+		http!!
 			.httpBasic().disable()
 			.csrf().disable()
-			.httpBasic().disable()
+			.exceptionHandling()
+			.and()
 			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			.and()
 			.authorizeRequests()
 			.antMatchers("/api/auth/**").permitAll()
+			.anyRequest().authenticated()
 			.and()
 			.addFilterBefore(JwtAuthenticationFilter(jwtResolver), UsernamePasswordAuthenticationFilter::class.java)
+		return http.build()
 	}
 }

--- a/src/main/kotlin/com/smu/som/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/smu/som/common/config/SecurityConfig.kt
@@ -13,12 +13,12 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @EnableWebSecurity
 class SecurityConfig(
-	private val jwtResolver: JwtResolver)
-{
+	private val jwtResolver: JwtResolver
+) {
 	@Bean
 	fun webSecurityCustomizer(): WebSecurityCustomizer? {
-		return WebSecurityCustomizer {
-			web: WebSecurity -> web.ignoring().antMatchers("/api/auth/**")
+		return WebSecurityCustomizer { web: WebSecurity ->
+			web.ignoring().antMatchers("/api/auth/**")
 		}
 	}
 

--- a/src/main/kotlin/com/smu/som/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/smu/som/common/config/SecurityConfig.kt
@@ -1,0 +1,33 @@
+package com.smu.som.common.config
+
+import com.smu.som.common.jwt.filter.JwtAuthenticationFilter
+import com.smu.som.common.jwt.util.JwtResolver
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.builders.WebSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+
+@EnableWebSecurity
+class SecurityConfig(
+	private val jwtResolver: JwtResolver
+) : WebSecurityConfigurerAdapter() {
+	override fun configure(web: WebSecurity) {
+		web
+			.ignoring().antMatchers("/api/auth/**")
+	}
+
+	override fun configure(http: HttpSecurity) {
+		http
+			.httpBasic().disable()
+			.csrf().disable()
+			.httpBasic().disable()
+			.sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+			.and()
+			.authorizeRequests()
+			.antMatchers("/api/auth/**").permitAll()
+			.and()
+			.addFilterBefore(JwtAuthenticationFilter(jwtResolver), UsernamePasswordAuthenticationFilter::class.java)
+	}
+}

--- a/src/main/kotlin/com/smu/som/common/jwt/filter/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/smu/som/common/jwt/filter/JwtAuthenticationFilter.kt
@@ -1,0 +1,48 @@
+package com.smu.som.common.jwt.filter
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.smu.som.common.jwt.util.JwtResolver
+import com.smu.som.controller.error.ErrorCode
+import com.smu.som.controller.error.ErrorResponse
+import io.jsonwebtoken.ExpiredJwtException
+import org.springframework.http.MediaType
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.GenericFilterBean
+import javax.servlet.FilterChain
+import javax.servlet.ServletRequest
+import javax.servlet.ServletResponse
+import javax.servlet.http.HttpServletRequest
+import javax.servlet.http.HttpServletResponse
+
+class JwtAuthenticationFilter(
+	private val jwtResolver: JwtResolver
+) : GenericFilterBean() {
+	override fun doFilter(request: ServletRequest, response: ServletResponse, chain: FilterChain) {
+		try {
+			val accessToken: String = jwtResolver.resolveAccessToken(request as HttpServletRequest)
+			jwtResolver.parseToken(accessToken)
+			setAuthentication(accessToken)
+		} catch (e: ExpiredJwtException) {
+			sendErrorResponse(response as HttpServletResponse, ErrorCode.EXPIRED_JWT)
+			return
+		} catch (e: Exception) {
+			sendErrorResponse(response as HttpServletResponse, ErrorCode.INVALID_JWT)
+			return
+		}
+		chain.doFilter(request, response)
+	}
+
+	private fun setAuthentication(accessToken: String) {
+		val authentication = jwtResolver.getAuthentication(accessToken)
+		SecurityContextHolder.getContext().authentication = authentication
+	}
+
+	private fun sendErrorResponse(response: HttpServletResponse, errorCode: ErrorCode) {
+		val errorResponse = ErrorResponse.of(errorCode)
+		val mapper = jacksonObjectMapper()
+		response.characterEncoding = "UTF-8"
+		response.status = errorCode.status.value()
+		response.contentType = MediaType.APPLICATION_JSON_VALUE
+		response.writer.write(mapper.writeValueAsString(errorResponse))
+	}
+}

--- a/src/main/kotlin/com/smu/som/common/jwt/service/JwtService.kt
+++ b/src/main/kotlin/com/smu/som/common/jwt/service/JwtService.kt
@@ -1,0 +1,37 @@
+package com.smu.som.common.jwt.service
+
+import com.smu.som.common.jwt.util.JwtProvider
+import com.smu.som.domain.user.oauth.OAuth2ServiceFactory
+import com.smu.som.controller.error.BusinessException
+import com.smu.som.controller.error.ErrorCode
+import com.smu.som.domain.user.dto.JwtTokenDTO
+import com.smu.som.domain.user.dto.SignUpRequestDTO
+import com.smu.som.domain.user.entity.Oauth2Provider
+import com.smu.som.domain.user.entity.User
+import com.smu.som.domain.user.service.UserService
+import org.springframework.stereotype.Service
+
+@Service
+class JwtService (
+	private val jwtProvider: JwtProvider,
+	private val userService: UserService,
+	private val oAuth2ServiceFactory: OAuth2ServiceFactory
+	){
+	fun issue(oauth2DTO: SignUpRequestDTO): JwtTokenDTO {
+		val oAuth2Id: String = oAuth2ServiceFactory
+			.getOAuthService(Oauth2Provider.valueOf(oauth2DTO.oauth2Provider.uppercase()))
+			.getOAuth2User(oauth2DTO.oauth2AccessToken)
+			.oauth2Id
+
+		val user: User = userService.findByOauth2Id(oAuth2Id)
+			?: throw BusinessException(ErrorCode.USER_NOT_FOUND)
+
+		val accessToken: String = jwtProvider.createAccessToken(user.oauth2Id)
+		val refreshToken: String = jwtProvider.createRefreshToken()
+
+		return JwtTokenDTO(
+			accessToken = accessToken,
+			refreshToken = refreshToken
+		)
+	}
+}

--- a/src/main/kotlin/com/smu/som/common/jwt/service/JwtService.kt
+++ b/src/main/kotlin/com/smu/som/common/jwt/service/JwtService.kt
@@ -5,6 +5,7 @@ import com.smu.som.domain.user.oauth.OAuth2ServiceFactory
 import com.smu.som.controller.error.BusinessException
 import com.smu.som.controller.error.ErrorCode
 import com.smu.som.domain.user.dto.JwtTokenDTO
+import com.smu.som.domain.user.dto.SignInRequestDTO
 import com.smu.som.domain.user.dto.SignUpRequestDTO
 import com.smu.som.domain.user.entity.Oauth2Provider
 import com.smu.som.domain.user.entity.User
@@ -17,10 +18,10 @@ class JwtService (
 	private val userService: UserService,
 	private val oAuth2ServiceFactory: OAuth2ServiceFactory
 	){
-	fun issue(oauth2DTO: SignUpRequestDTO): JwtTokenDTO {
+	fun issue(oauth2Provider: String, oauth2AccessToken: String): JwtTokenDTO {
 		val oAuth2Id: String = oAuth2ServiceFactory
-			.getOAuthService(Oauth2Provider.valueOf(oauth2DTO.oauth2Provider.uppercase()))
-			.getOAuth2User(oauth2DTO.oauth2AccessToken)
+			.getOAuthService(Oauth2Provider.valueOf(oauth2Provider.uppercase()))
+			.getOAuth2User(oauth2AccessToken)
 			.oauth2Id
 
 		val user: User = userService.findByOauth2Id(oAuth2Id)

--- a/src/main/kotlin/com/smu/som/common/jwt/user/UserDetailsImpl.kt
+++ b/src/main/kotlin/com/smu/som/common/jwt/user/UserDetailsImpl.kt
@@ -1,0 +1,37 @@
+package com.smu.som.common.jwt.user
+
+import com.smu.som.domain.user.entity.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+class UserDetailsImpl(
+	val user: User
+) : UserDetails {
+	override fun getAuthorities(): MutableCollection<out GrantedAuthority>? {
+		return null
+	}
+
+	override fun getPassword(): String? {
+		return null
+	}
+
+	override fun getUsername(): String {
+		return user.oauth2Id
+	}
+
+	override fun isAccountNonExpired(): Boolean {
+		return true
+	}
+
+	override fun isAccountNonLocked(): Boolean {
+		return true
+	}
+
+	override fun isCredentialsNonExpired(): Boolean {
+		return true
+	}
+
+	override fun isEnabled(): Boolean {
+		return true
+	}
+}

--- a/src/main/kotlin/com/smu/som/common/jwt/user/UserDetailsServiceImpl.kt
+++ b/src/main/kotlin/com/smu/som/common/jwt/user/UserDetailsServiceImpl.kt
@@ -1,0 +1,18 @@
+package com.smu.som.common.jwt.user
+
+import com.smu.som.controller.error.BusinessException
+import com.smu.som.controller.error.ErrorCode
+import com.smu.som.domain.user.repository.UserRepository
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Service
+
+@Service
+class UserDetailsServiceImpl(
+	private val userRepository: UserRepository
+) : UserDetailsService {
+	override fun loadUserByUsername(username: String): UserDetails {
+		return UserDetailsImpl(userRepository.findByOauth2Id(username)
+			?: throw BusinessException(ErrorCode.USER_NOT_FOUND))
+	}
+}

--- a/src/main/kotlin/com/smu/som/common/jwt/util/JwtProvider.kt
+++ b/src/main/kotlin/com/smu/som/common/jwt/util/JwtProvider.kt
@@ -1,0 +1,41 @@
+package com.smu.som.common.jwt.util
+
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.nio.charset.StandardCharsets
+import java.security.Key
+import java.util.*
+
+@Component
+@Transactional(readOnly = true)
+class JwtProvider(
+	@Value("\${jwt.secret}") private val secretKey: String,
+	@Value("\${jwt.access-token-expiry}") private val accessTokenValidTime: Int,
+	@Value("\${jwt.refresh-token-expiry}") private val refreshTokenValidTime: Long
+) {
+	private val key: Key = Keys.hmacShaKeyFor(secretKey.toByteArray(StandardCharsets.UTF_8))
+
+	fun createAccessToken(oAuth2Id: String): String {
+		val claims: Claims = Jwts.claims().setSubject(oAuth2Id)
+		val now = Date()
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(now)
+			.setExpiration(Date(now.time + accessTokenValidTime))
+			.signWith(key)
+			.compact()
+	}
+
+	fun createRefreshToken(): String {
+		val now = Date()
+		return Jwts.builder()
+			.setIssuedAt(now)
+			.setExpiration(Date(now.time + refreshTokenValidTime))
+			.signWith(key)
+			.compact()
+	}
+}

--- a/src/main/kotlin/com/smu/som/common/jwt/util/JwtResolver.kt
+++ b/src/main/kotlin/com/smu/som/common/jwt/util/JwtResolver.kt
@@ -1,0 +1,61 @@
+package com.smu.som.common.jwt.util
+
+import com.smu.som.common.jwt.user.UserDetailsImpl
+import com.smu.som.common.jwt.user.UserDetailsServiceImpl
+import io.jsonwebtoken.Claims
+import io.jsonwebtoken.ExpiredJwtException
+import io.jsonwebtoken.Jws
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.nio.charset.StandardCharsets
+import java.security.Key
+import javax.servlet.http.HttpServletRequest
+
+@Component
+@Transactional(readOnly = true)
+class JwtResolver(
+	@Value("\${jwt.secret}") private val SECRET_KEY: String,
+	@Value("\${jwt.access-token-header}") private val ACCESS_TOKEN_HEADER: String,
+	@Value("\${jwt.refresh-token-header}") private val REFRESH_TOKEN_HEADER: String,
+	private val userDetailsService: UserDetailsServiceImpl
+) {
+	private val key: Key = Keys.hmacShaKeyFor(SECRET_KEY.toByteArray(StandardCharsets.UTF_8))
+
+	fun getAuthentication(token: String): Authentication {
+		val userDetails = userDetailsService.loadUserByUsername(getUserPk(token))
+		return UsernamePasswordAuthenticationToken(userDetails, "", userDetails.authorities)
+	}
+
+	fun getFromSecurityContextHolder(): UserDetailsImpl {
+		return SecurityContextHolder.getContext().authentication.principal as UserDetailsImpl
+	}
+
+	fun resolveAccessToken(request: HttpServletRequest): String {
+		return request.getHeader(ACCESS_TOKEN_HEADER).replace("Bearer", "").trim()
+	}
+
+	fun resolveRefreshToken(request: HttpServletRequest): String {
+		return request.getHeader(REFRESH_TOKEN_HEADER)
+	}
+
+	fun parseToken(token: String): Jws<Claims> {
+		return Jwts.parserBuilder()
+			.setSigningKey(key)
+			.build()
+			.parseClaimsJws(token)
+	}
+
+	private fun getUserPk(token: String): String {
+		return try {
+			parseToken(token).body.subject
+		} catch (e: ExpiredJwtException) {
+			e.claims.subject
+		}
+	}
+}

--- a/src/main/kotlin/com/smu/som/common/util/Constants.kt
+++ b/src/main/kotlin/com/smu/som/common/util/Constants.kt
@@ -3,5 +3,6 @@ package com.smu.som.common.util
 class Constants {
 	companion object {
 		const val PROVIDER_KAKAO_PREFIX = "kakao"
+		const val PROVIDER_NAVER_PREFIX = "naver"
 	}
 }

--- a/src/main/kotlin/com/smu/som/controller/api/AuthController.kt
+++ b/src/main/kotlin/com/smu/som/controller/api/AuthController.kt
@@ -1,5 +1,7 @@
 package com.smu.som.controller.api
 
+import com.smu.som.controller.error.BusinessException
+import com.smu.som.controller.error.ErrorCode
 import com.smu.som.domain.user.dto.SignUpRequestDTO
 import com.smu.som.domain.user.dto.SignUpResponseDTO
 import com.smu.som.domain.user.service.AuthService
@@ -16,7 +18,17 @@ class AuthController(
 	private val authService: AuthService
 ) {
 	@PostMapping("/signup")
-	fun signup(@RequestBody oAuth2DTO: SignUpRequestDTO): ResponseEntity<SignUpResponseDTO> {
-		return ResponseEntity.ok().body(authService.signUp(oAuth2DTO))
+	fun signup(@RequestBody signUpRequestDTO: SignUpRequestDTO): ResponseEntity<SignUpResponseDTO> {
+		if (!isValidSignUpRequest(signUpRequestDTO)) {
+			throw BusinessException(ErrorCode.INVALID_SIGNUP_REQUEST)
+		}
+		return ResponseEntity.ok().body(authService.signUp(signUpRequestDTO))
+	}
+
+	private fun isValidSignUpRequest(signUpRequestDTO: SignUpRequestDTO): Boolean {
+		if (signUpRequestDTO.anniversary != null && signUpRequestDTO.maritalStatus == null) {
+			return false
+		}
+		return true
 	}
 }

--- a/src/main/kotlin/com/smu/som/controller/api/AuthController.kt
+++ b/src/main/kotlin/com/smu/som/controller/api/AuthController.kt
@@ -2,6 +2,8 @@ package com.smu.som.controller.api
 
 import com.smu.som.controller.error.BusinessException
 import com.smu.som.controller.error.ErrorCode
+import com.smu.som.domain.user.dto.JwtTokenDTO
+import com.smu.som.domain.user.dto.SignInRequestDTO
 import com.smu.som.domain.user.dto.SignUpRequestDTO
 import com.smu.som.domain.user.dto.SignUpResponseDTO
 import com.smu.som.domain.user.service.AuthService
@@ -23,6 +25,13 @@ class AuthController(
 			throw BusinessException(ErrorCode.INVALID_SIGNUP_REQUEST)
 		}
 		return ResponseEntity.ok().body(authService.signUp(signUpRequestDTO))
+	}
+
+	@PostMapping("/signin")
+	fun signin(@RequestBody signInRequestDTO: SignInRequestDTO): ResponseEntity<JwtTokenDTO> {
+		return ResponseEntity.ok().body(
+			authService.signin(signInRequestDTO)
+		)
 	}
 
 	private fun isValidSignUpRequest(signUpRequestDTO: SignUpRequestDTO): Boolean {

--- a/src/main/kotlin/com/smu/som/controller/api/AuthController.kt
+++ b/src/main/kotlin/com/smu/som/controller/api/AuthController.kt
@@ -1,0 +1,22 @@
+package com.smu.som.controller.api
+
+import com.smu.som.domain.user.dto.SignUpRequestDTO
+import com.smu.som.domain.user.dto.SignUpResponseDTO
+import com.smu.som.domain.user.service.AuthService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+
+@RestController
+@RequestMapping("/api/auth")
+class AuthController(
+	private val authService: AuthService
+) {
+	@PostMapping("/signup")
+	fun signup(@RequestBody oAuth2DTO: SignUpRequestDTO): ResponseEntity<SignUpResponseDTO> {
+		return ResponseEntity.ok().body(authService.signUp(oAuth2DTO))
+	}
+}

--- a/src/main/kotlin/com/smu/som/controller/error/ErrorCode.kt
+++ b/src/main/kotlin/com/smu/som/controller/error/ErrorCode.kt
@@ -14,5 +14,6 @@ enum class ErrorCode(
 	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
 	USER_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
 	EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다."),
-	INVALID_JWT(HttpStatus.UNAUTHORIZED, "권한이 없는 회원의 접근입니다.")
+	INVALID_JWT(HttpStatus.UNAUTHORIZED, "권한이 없는 회원의 접근입니다."),
+	INVALID_SIGNUP_REQUEST(HttpStatus.BAD_REQUEST, "결혼 여부를 입력해주세요.")
 }

--- a/src/main/kotlin/com/smu/som/controller/error/ErrorCode.kt
+++ b/src/main/kotlin/com/smu/som/controller/error/ErrorCode.kt
@@ -8,5 +8,11 @@ enum class ErrorCode(
 ) {
 	//Common
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생하였습니다."),
-	QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 내역을 찾을 수 없습니다.")
+	QUESTION_NOT_FOUND(HttpStatus.NOT_FOUND, "요청하신 내역을 찾을 수 없습니다."),
+
+	//Auth
+	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 회원입니다."),
+	USER_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
+	EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다."),
+	INVALID_JWT(HttpStatus.UNAUTHORIZED, "권한이 없는 회원의 접근입니다.")
 }

--- a/src/main/kotlin/com/smu/som/controller/error/ErrorCode.kt
+++ b/src/main/kotlin/com/smu/som/controller/error/ErrorCode.kt
@@ -15,5 +15,6 @@ enum class ErrorCode(
 	USER_DUPLICATED(HttpStatus.BAD_REQUEST, "이미 존재하는 회원입니다."),
 	EXPIRED_JWT(HttpStatus.UNAUTHORIZED, "만료된 엑세스 토큰입니다."),
 	INVALID_JWT(HttpStatus.UNAUTHORIZED, "권한이 없는 회원의 접근입니다."),
-	INVALID_SIGNUP_REQUEST(HttpStatus.BAD_REQUEST, "결혼 여부를 입력해주세요.")
+	INVALID_SIGNUP_REQUEST(HttpStatus.BAD_REQUEST, "결혼 여부를 입력해주세요."),
+	OAUTH2_FAIL_EXCEPTION(HttpStatus.UNAUTHORIZED, "유효하지 않는 Oauth2 엑세스 토큰입니다.")
 }

--- a/src/main/kotlin/com/smu/som/controller/error/ExceptionHandler.kt
+++ b/src/main/kotlin/com/smu/som/controller/error/ExceptionHandler.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler
 class ExceptionHandler {
 	@ExceptionHandler(BusinessException::class)
 	fun handleBaseException(e: BusinessException): ResponseEntity<ErrorResponse> {
-		Logger.error(e.message)
+		Logger.error(e.errorCode.message)
 		return ResponseEntity.status(e.errorCode.status).body(ErrorResponse.of(e.errorCode))
 	}
 

--- a/src/main/kotlin/com/smu/som/domain/user/dto/JwtTokenDTO.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/dto/JwtTokenDTO.kt
@@ -1,0 +1,6 @@
+package com.smu.som.domain.user.dto
+
+data class JwtTokenDTO(
+	val accessToken: String,
+	val refreshToken: String
+)

--- a/src/main/kotlin/com/smu/som/domain/user/dto/Oauth2UserDTO.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/dto/Oauth2UserDTO.kt
@@ -1,9 +1,11 @@
 package com.smu.som.domain.user.dto
 
+import com.smu.som.domain.user.entity.Gender
+
 data class Oauth2UserDTO(
 	val oauth2Id: String,
 	val ageRange: String,
-	val gender: String,
+	val gender: Gender,
 	val nickname: String,
 	val email: String
 )

--- a/src/main/kotlin/com/smu/som/domain/user/dto/Oauth2UserDTO.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/dto/Oauth2UserDTO.kt
@@ -1,0 +1,8 @@
+package com.smu.som.domain.user.dto
+
+data class Oauth2UserDTO(
+	val oauth2Id: String,
+	val ageRange: String,
+	val gender: String,
+	val nickname: String
+)

--- a/src/main/kotlin/com/smu/som/domain/user/dto/Oauth2UserDTO.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/dto/Oauth2UserDTO.kt
@@ -4,5 +4,6 @@ data class Oauth2UserDTO(
 	val oauth2Id: String,
 	val ageRange: String,
 	val gender: String,
-	val nickname: String
+	val nickname: String,
+	val email: String
 )

--- a/src/main/kotlin/com/smu/som/domain/user/dto/SignInRequestDTO.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/dto/SignInRequestDTO.kt
@@ -1,0 +1,11 @@
+package com.smu.som.domain.user.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class SignInRequestDTO (
+	@JsonProperty("oauth2Provider")
+	val oauth2Provider: String,
+
+	@JsonProperty("oauth2AccessToken")
+	val oauth2AccessToken: String
+)

--- a/src/main/kotlin/com/smu/som/domain/user/dto/SignUpRequestDTO.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/dto/SignUpRequestDTO.kt
@@ -1,7 +1,7 @@
 package com.smu.som.domain.user.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import java.time.LocalDate
+import java.util.*
 
 data class SignUpRequestDTO (
 	@JsonProperty("oauth2Provider")
@@ -10,7 +10,9 @@ data class SignUpRequestDTO (
 	@JsonProperty("oauth2AccessToken")
 	val oauth2AccessToken: String,
 
-	val maritalStatus: Boolean,
+	@JsonProperty("maritalStatus")
+	val maritalStatus: Boolean? = null,
 
-	val date: LocalDate
+	@JsonProperty("anniversary")
+	val anniversary: Date? = null
 )

--- a/src/main/kotlin/com/smu/som/domain/user/dto/SignUpRequestDTO.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/dto/SignUpRequestDTO.kt
@@ -1,11 +1,16 @@
 package com.smu.som.domain.user.dto
 
 import com.fasterxml.jackson.annotation.JsonProperty
+import java.time.LocalDate
 
 data class SignUpRequestDTO (
 	@JsonProperty("oauth2Provider")
-	var oauth2Provider: String,
+	val oauth2Provider: String,
 
 	@JsonProperty("oauth2AccessToken")
-	var oauth2AccessToken: String
+	val oauth2AccessToken: String,
+
+	val maritalStatus: Boolean,
+
+	val date: LocalDate
 )

--- a/src/main/kotlin/com/smu/som/domain/user/dto/SignUpRequestDTO.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/dto/SignUpRequestDTO.kt
@@ -1,0 +1,11 @@
+package com.smu.som.domain.user.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class SignUpRequestDTO (
+	@JsonProperty("oauth2Provider")
+	var oauth2Provider: String,
+
+	@JsonProperty("oauth2AccessToken")
+	var oauth2AccessToken: String
+)

--- a/src/main/kotlin/com/smu/som/domain/user/dto/SignUpResponseDTO.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/dto/SignUpResponseDTO.kt
@@ -1,0 +1,6 @@
+package com.smu.som.domain.user.dto
+
+data class SignUpResponseDTO(
+	val jwtToken: JwtTokenDTO,
+	val oauth2Id: String,
+)

--- a/src/main/kotlin/com/smu/som/domain/user/entity/Gender.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/entity/Gender.kt
@@ -1,5 +1,7 @@
 package com.smu.som.domain.user.entity
 
-enum class Gender{
-	FEMALE, MALE, NONE
+enum class Gender(
+	private val initial: String
+) {
+	FEMALE("f"), MALE("m"), NONE("n");
 }

--- a/src/main/kotlin/com/smu/som/domain/user/entity/Gender.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/entity/Gender.kt
@@ -1,0 +1,5 @@
+package com.smu.som.domain.user.entity
+
+enum class Gender{
+	FEMALE, MALE, NONE
+}

--- a/src/main/kotlin/com/smu/som/domain/user/entity/Oauth2Provider.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/entity/Oauth2Provider.kt
@@ -1,0 +1,5 @@
+package com.smu.som.domain.user.entity
+
+enum class Oauth2Provider {
+	KAKAO, NAVER
+}

--- a/src/main/kotlin/com/smu/som/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/entity/User.kt
@@ -1,6 +1,7 @@
 package com.smu.som.domain.user.entity
 
 import com.smu.som.domain.user.dto.Oauth2UserDTO
+import java.time.LocalDate
 import javax.persistence.*
 
 @Entity
@@ -17,15 +18,25 @@ class User(
 	@Enumerated(EnumType.STRING)
 	var gender: Gender?,
 
-	var nickname: String
+	var nickname: String,
+
+	var email: String?,
+
+	var maritalStatus: Boolean = false,
+
+	var date: LocalDate? = null
+
 ) {
 	companion object {
-		fun of(oAuth2User: Oauth2UserDTO): User {
+		fun of(oAuth2User: Oauth2UserDTO, maritalStatus: Boolean, date: LocalDate?): User {
 			return User(
 				oauth2Id = oAuth2User.oauth2Id,
 				ageRange = oAuth2User.ageRange,
 				gender = Gender.valueOf(oAuth2User.gender),
-				nickname = oAuth2User.nickname
+				nickname = oAuth2User.nickname,
+				email = oAuth2User.email,
+				maritalStatus = maritalStatus,
+				date = date
 			)
 		}
 	}

--- a/src/main/kotlin/com/smu/som/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/entity/User.kt
@@ -32,7 +32,7 @@ class User(
 			return User(
 				oauth2Id = oAuth2User.oauth2Id,
 				ageRange = oAuth2User.ageRange,
-				gender = Gender.valueOf(oAuth2User.gender),
+				gender = oAuth2User.gender,
 				nickname = oAuth2User.nickname,
 				email = oAuth2User.email,
 				maritalStatus = maritalStatus,

--- a/src/main/kotlin/com/smu/som/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/entity/User.kt
@@ -1,7 +1,7 @@
 package com.smu.som.domain.user.entity
 
 import com.smu.som.domain.user.dto.Oauth2UserDTO
-import java.time.LocalDate
+import java.util.*
 import javax.persistence.*
 
 @Entity
@@ -22,13 +22,13 @@ class User(
 
 	var email: String?,
 
-	var maritalStatus: Boolean = false,
+	var maritalStatus: Boolean? = null,
 
-	var date: LocalDate? = null
+	var anniversary: Date? = null
 
 ) {
 	companion object {
-		fun of(oAuth2User: Oauth2UserDTO, maritalStatus: Boolean, date: LocalDate?): User {
+		fun of(oAuth2User: Oauth2UserDTO, maritalStatus: Boolean?, anniversary: Date?): User {
 			return User(
 				oauth2Id = oAuth2User.oauth2Id,
 				ageRange = oAuth2User.ageRange,
@@ -36,7 +36,7 @@ class User(
 				nickname = oAuth2User.nickname,
 				email = oAuth2User.email,
 				maritalStatus = maritalStatus,
-				date = date
+				anniversary = anniversary
 			)
 		}
 	}

--- a/src/main/kotlin/com/smu/som/domain/user/entity/User.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/entity/User.kt
@@ -1,0 +1,32 @@
+package com.smu.som.domain.user.entity
+
+import com.smu.som.domain.user.dto.Oauth2UserDTO
+import javax.persistence.*
+
+@Entity
+@Table(name = "user")
+class User(
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	var id: Long? = null,
+
+	var oauth2Id: String,
+
+	var ageRange: String?,
+
+	@Enumerated(EnumType.STRING)
+	var gender: Gender?,
+
+	var nickname: String
+) {
+	companion object {
+		fun of(oAuth2User: Oauth2UserDTO): User {
+			return User(
+				oauth2Id = oAuth2User.oauth2Id,
+				ageRange = oAuth2User.ageRange,
+				gender = Gender.valueOf(oAuth2User.gender),
+				nickname = oAuth2User.nickname
+			)
+		}
+	}
+}

--- a/src/main/kotlin/com/smu/som/domain/user/oauth/KakaoOauth2ServiceImpl.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/oauth/KakaoOauth2ServiceImpl.kt
@@ -53,12 +53,14 @@ class KakaoOauth2ServiceImpl(
 			.asText()
 		val gender = kakao_account.get("gender").asText().uppercase()
 		val ageRange = kakao_account.get("age_range").asText()
+		val email = kakao_account.get("email").asText()
 
 		return Oauth2UserDTO(
 			oauth2Id = "$PROVIDER_KAKAO_PREFIX:$oAuth2Id",
 			nickname = nickname,
 			ageRange = ageRange,
-			gender = gender
+			gender = gender,
+			email = email
 		)
 	}
 }

--- a/src/main/kotlin/com/smu/som/domain/user/oauth/KakaoOauth2ServiceImpl.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/oauth/KakaoOauth2ServiceImpl.kt
@@ -1,0 +1,64 @@
+package com.smu.som.domain.user.oauth
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.smu.som.domain.user.dto.Oauth2UserDTO
+import com.smu.som.common.util.Constants.Companion.PROVIDER_KAKAO_PREFIX
+import com.smu.som.controller.error.BusinessException
+import com.smu.som.controller.error.ErrorCode
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.RestTemplate
+
+class KakaoOauth2ServiceImpl(
+	private val restTemplate: RestTemplate,
+	private val objectMapper: ObjectMapper
+) : OAuth2Service {
+	private val KAKAO_USER_INFO_URI: String = "https://kapi.kakao.com/v2/user/me"
+
+	override fun getOAuth2User(oAuth2AccessToken: String): Oauth2UserDTO {
+		val userJson = getProfileInfoFromProvider(oAuth2AccessToken)
+		return buildOAuth2User(userJson)
+	}
+
+	private fun getProfileInfoFromProvider(oAuth2AccessToken: String): JsonNode {
+		val response: ResponseEntity<String> = restTemplate.postForEntity(
+			KAKAO_USER_INFO_URI,
+			buildRequest(oAuth2AccessToken),
+			String::class.java
+		)
+		return try {
+			objectMapper.readTree(response.body)
+		} catch (e: JsonProcessingException) {
+			throw BusinessException(ErrorCode.INTERNAL_SERVER_ERROR)
+		}
+	}
+
+	private fun buildRequest(oAuth2AccessToken: String): HttpEntity<*> {
+		val headers = HttpHeaders()
+		headers.contentType = MediaType.APPLICATION_FORM_URLENCODED
+		headers.setBearerAuth(oAuth2AccessToken)
+		return HttpEntity(null, headers)
+	}
+
+	private fun buildOAuth2User(jsonNode: JsonNode): Oauth2UserDTO {
+		val kakao_account = jsonNode.get("kakao_account")
+		val oAuth2Id = jsonNode.get("id").asText()
+		val nickname = kakao_account
+			.get("profile")
+			.get("nickname")
+			.asText()
+		val gender = kakao_account.get("gender").asText().uppercase()
+		val ageRange = kakao_account.get("age_range").asText()
+
+		return Oauth2UserDTO(
+			oauth2Id = "$PROVIDER_KAKAO_PREFIX:$oAuth2Id",
+			nickname = nickname,
+			ageRange = ageRange,
+			gender = gender
+		)
+	}
+}

--- a/src/main/kotlin/com/smu/som/domain/user/oauth/NaverOauth2ServiceImpl.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/oauth/NaverOauth2ServiceImpl.kt
@@ -1,0 +1,11 @@
+package com.smu.som.domain.user.oauth
+
+import com.smu.som.domain.user.dto.Oauth2UserDTO
+
+class NaverOauth2ServiceImpl(
+
+) : OAuth2Service {
+	override fun getOAuth2User(oAuth2AccessToken: String): Oauth2UserDTO {
+		TODO("Not yet implemented")
+	}
+}

--- a/src/main/kotlin/com/smu/som/domain/user/oauth/NaverOauth2ServiceImpl.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/oauth/NaverOauth2ServiceImpl.kt
@@ -1,11 +1,74 @@
 package com.smu.som.domain.user.oauth
 
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.smu.som.common.util.Constants
+import com.smu.som.controller.error.BusinessException
+import com.smu.som.controller.error.ErrorCode
 import com.smu.som.domain.user.dto.Oauth2UserDTO
+import com.smu.som.domain.user.entity.Gender
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.client.HttpClientErrorException
+import org.springframework.web.client.RestTemplate
 
 class NaverOauth2ServiceImpl(
-
+	private val restTemplate: RestTemplate,
+	private val objectMapper: ObjectMapper
 ) : OAuth2Service {
+	private val NAVER_USER_INFO_URI: String = "https://openapi.naver.com/v1/nid/me"
 	override fun getOAuth2User(oAuth2AccessToken: String): Oauth2UserDTO {
-		TODO("Not yet implemented")
+		val userJson = getProfileInfoFromProvider(oAuth2AccessToken)
+		return buildOAuth2User(userJson)
+	}
+
+	private fun getProfileInfoFromProvider(oAuth2AccessToken: String): JsonNode {
+		val response: ResponseEntity<String> = try {
+			restTemplate.postForEntity(
+				NAVER_USER_INFO_URI,
+				buildRequest(oAuth2AccessToken),
+				String::class.java)
+		} catch (e: HttpClientErrorException) {
+			throw BusinessException(ErrorCode.OAUTH2_FAIL_EXCEPTION)
+		}
+
+		return try {
+			objectMapper.readTree(response.body)
+		} catch (e: JsonProcessingException) {
+			throw BusinessException(ErrorCode.INTERNAL_SERVER_ERROR)
+		}
+	}
+
+	private fun buildRequest(oAuth2AccessToken: String): HttpEntity<*> {
+		val headers = HttpHeaders()
+		headers.contentType = MediaType.APPLICATION_FORM_URLENCODED
+		headers.setBearerAuth(oAuth2AccessToken)
+		return HttpEntity(null, headers)
+	}
+
+	private fun buildOAuth2User(jsonNode: JsonNode): Oauth2UserDTO {
+		val naver_account = jsonNode.get("response")
+		val oAuth2Id = naver_account.get("id").asText()
+		val nickname = naver_account.get("nickname").asText()
+		val gender = getGender(naver_account.get("gender").asText())
+		val ageRange = naver_account.get("age").asText().replace("-", "~")
+		val email = naver_account.get("email").asText()
+
+		return Oauth2UserDTO(
+			oauth2Id = "${Constants.PROVIDER_NAVER_PREFIX}:$oAuth2Id",
+			nickname = nickname,
+			ageRange = ageRange,
+			gender = gender,
+			email = email
+		)
+	}
+
+	private fun getGender(initial: String) = when (initial) {
+		"F" -> Gender.FEMALE
+		"M" -> Gender.MALE
+		else -> Gender.NONE
 	}
 }

--- a/src/main/kotlin/com/smu/som/domain/user/oauth/OAuth2Service.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/oauth/OAuth2Service.kt
@@ -1,0 +1,9 @@
+package com.smu.som.domain.user.oauth
+
+import com.smu.som.domain.user.dto.Oauth2UserDTO
+import org.springframework.stereotype.Service
+
+@Service
+interface OAuth2Service {
+	fun getOAuth2User(oAuth2AccessToken: String): Oauth2UserDTO
+}

--- a/src/main/kotlin/com/smu/som/domain/user/oauth/OAuth2ServiceFactory.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/oauth/OAuth2ServiceFactory.kt
@@ -1,0 +1,19 @@
+package com.smu.som.domain.user.oauth
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.smu.som.domain.user.entity.Oauth2Provider
+import org.springframework.stereotype.Component
+import org.springframework.web.client.RestTemplate
+
+@Component
+class OAuth2ServiceFactory(
+	private val restTemplate: RestTemplate,
+	private val objectMapper: ObjectMapper
+) {
+	fun getOAuthService(authorizationServer: Oauth2Provider): OAuth2Service {
+		return when (authorizationServer) {
+			Oauth2Provider.KAKAO -> KakaoOauth2ServiceImpl(restTemplate, objectMapper)
+			Oauth2Provider.NAVER -> NaverOauth2ServiceImpl()
+		}
+	}
+}

--- a/src/main/kotlin/com/smu/som/domain/user/oauth/OAuth2ServiceFactory.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/oauth/OAuth2ServiceFactory.kt
@@ -13,7 +13,7 @@ class OAuth2ServiceFactory(
 	fun getOAuthService(authorizationServer: Oauth2Provider): OAuth2Service {
 		return when (authorizationServer) {
 			Oauth2Provider.KAKAO -> KakaoOauth2ServiceImpl(restTemplate, objectMapper)
-			Oauth2Provider.NAVER -> NaverOauth2ServiceImpl()
+			Oauth2Provider.NAVER -> NaverOauth2ServiceImpl(restTemplate, objectMapper)
 		}
 	}
 }

--- a/src/main/kotlin/com/smu/som/domain/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/repository/UserRepository.kt
@@ -1,0 +1,10 @@
+package com.smu.som.domain.user.repository
+
+import com.smu.som.domain.user.entity.User
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserRepository : JpaRepository<User, Long> {
+	fun findByOauth2Id(oauth2Id: String): User?
+
+	fun existsByOauth2Id(oauth2Id: String): Boolean
+}

--- a/src/main/kotlin/com/smu/som/domain/user/service/AuthService.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/service/AuthService.kt
@@ -19,19 +19,21 @@ class AuthService(
 	private val jwtService: JwtService
 ) {
 	@Transactional
-	fun signUp(oAuth2DTO: SignUpRequestDTO): SignUpResponseDTO {
+	fun signUp(signUpRequestDTO: SignUpRequestDTO): SignUpResponseDTO {
 		val oAuth2User = oAuth2ServiceFactory
-			.getOAuthService(Oauth2Provider.valueOf(oAuth2DTO.oauth2Provider.uppercase()))
-			.getOAuth2User(oAuth2DTO.oauth2AccessToken)
+			.getOAuthService(Oauth2Provider.valueOf(signUpRequestDTO.oauth2Provider.uppercase()))
+			.getOAuth2User(signUpRequestDTO.oauth2AccessToken)
 
 		if (userService.existsByOauth2Id(oAuth2User.oauth2Id)) {
 			throw BusinessException(ErrorCode.USER_DUPLICATED)
 		}
 
-		val savedUser: User = userService.saveUser(User.of(oAuth2User))
+		val savedUser: User = userService.saveUser(
+			User.of(oAuth2User, signUpRequestDTO.maritalStatus, signUpRequestDTO.date)
+		)
 
 		return SignUpResponseDTO(
-			jwtToken = jwtService.issue(oAuth2DTO),
+			jwtToken = jwtService.issue(signUpRequestDTO),
 			oauth2Id = savedUser.oauth2Id
 		)
 	}

--- a/src/main/kotlin/com/smu/som/domain/user/service/AuthService.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/service/AuthService.kt
@@ -4,6 +4,8 @@ import com.smu.som.common.jwt.service.JwtService
 import com.smu.som.domain.user.oauth.OAuth2ServiceFactory
 import com.smu.som.controller.error.BusinessException
 import com.smu.som.controller.error.ErrorCode
+import com.smu.som.domain.user.dto.JwtTokenDTO
+import com.smu.som.domain.user.dto.SignInRequestDTO
 import com.smu.som.domain.user.dto.SignUpRequestDTO
 import com.smu.som.domain.user.dto.SignUpResponseDTO
 import com.smu.som.domain.user.entity.Oauth2Provider
@@ -33,8 +35,12 @@ class AuthService(
 		)
 
 		return SignUpResponseDTO(
-			jwtToken = jwtService.issue(signUpRequestDTO),
+			jwtToken = jwtService.issue(signUpRequestDTO.oauth2Provider, signUpRequestDTO.oauth2AccessToken),
 			oauth2Id = savedUser.oauth2Id
 		)
 	}
+
+	fun signin(signInRequestDTO: SignInRequestDTO): JwtTokenDTO =
+		jwtService.issue(signInRequestDTO.oauth2Provider, signInRequestDTO.oauth2AccessToken)
+
 }

--- a/src/main/kotlin/com/smu/som/domain/user/service/AuthService.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/service/AuthService.kt
@@ -1,0 +1,38 @@
+package com.smu.som.domain.user.service
+
+import com.smu.som.common.jwt.service.JwtService
+import com.smu.som.domain.user.oauth.OAuth2ServiceFactory
+import com.smu.som.controller.error.BusinessException
+import com.smu.som.controller.error.ErrorCode
+import com.smu.som.domain.user.dto.SignUpRequestDTO
+import com.smu.som.domain.user.dto.SignUpResponseDTO
+import com.smu.som.domain.user.entity.Oauth2Provider
+import com.smu.som.domain.user.entity.User
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class AuthService(
+	private val oAuth2ServiceFactory: OAuth2ServiceFactory,
+	private val userService: UserService,
+	private val jwtService: JwtService
+) {
+	@Transactional
+	fun signUp(oAuth2DTO: SignUpRequestDTO): SignUpResponseDTO {
+		val oAuth2User = oAuth2ServiceFactory
+			.getOAuthService(Oauth2Provider.valueOf(oAuth2DTO.oauth2Provider.uppercase()))
+			.getOAuth2User(oAuth2DTO.oauth2AccessToken)
+
+		if (userService.existsByOauth2Id(oAuth2User.oauth2Id)) {
+			throw BusinessException(ErrorCode.USER_DUPLICATED)
+		}
+
+		val savedUser: User = userService.saveUser(User.of(oAuth2User))
+
+		return SignUpResponseDTO(
+			jwtToken = jwtService.issue(oAuth2DTO),
+			oauth2Id = savedUser.oauth2Id
+		)
+	}
+}

--- a/src/main/kotlin/com/smu/som/domain/user/service/AuthService.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/service/AuthService.kt
@@ -29,7 +29,7 @@ class AuthService(
 		}
 
 		val savedUser: User = userService.saveUser(
-			User.of(oAuth2User, signUpRequestDTO.maritalStatus, signUpRequestDTO.date)
+			User.of(oAuth2User, signUpRequestDTO.maritalStatus, signUpRequestDTO.anniversary)
 		)
 
 		return SignUpResponseDTO(

--- a/src/main/kotlin/com/smu/som/domain/user/service/UserService.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/service/UserService.kt
@@ -1,0 +1,21 @@
+package com.smu.som.domain.user.service
+
+import com.smu.som.domain.user.entity.User
+import com.smu.som.domain.user.repository.UserRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class UserService(
+	private val userRepository: UserRepository
+) {
+	fun existsByOauth2Id(oauth2Id: String)
+	= userRepository.existsByOauth2Id(oauth2Id)
+
+	fun findByOauth2Id(oauth2Id: String)
+	= userRepository.findByOauth2Id(oauth2Id)
+
+	@Transactional
+	fun saveUser(user: User) = userRepository.save(user)
+}


### PR DESCRIPTION
## 연결된 이슈 
- resolved #19 

## 작업 내용
- 카카오 회원가입 후 access token, refresh token 발급

## 논의 사항
- 성별, 연령대 같은 경우는 선택해야 가져올 수 있는 데이터여서.. 만약 유저가 동의하지 않는다면 어떻게 해야할 지 고민이 되어서 선PR 날려봐..ㅠ-ㅠ (카카오 검수 후 필수 동의로 전환할 수 있을 것 같아)
- 또 전체 회의 한 번 거친 후에 user entity 채워야 할 것 같아! 
<img width="889" alt="image" src="https://user-images.githubusercontent.com/50178026/184268263-feb5f5ce-5a71-44cc-890c-01dc3222a230.png">

