### PR TITLE
:sparkles: 현재 로그인한 유저 annotation 작성

### DIFF
--- a/src/main/kotlin/com/smu/som/common/annotation/CurrentUser.kt
+++ b/src/main/kotlin/com/smu/som/common/annotation/CurrentUser.kt
@@ -1,0 +1,8 @@
+package com.smu.som.common.annotation
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+
+@Target(AnnotationTarget.VALUE_PARAMETER)
+@Retention(AnnotationRetention.RUNTIME)
+@AuthenticationPrincipal(expression = "#this == 'anonymousUser' ? null : user")
+annotation class CurrentUser


### PR DESCRIPTION
## 연결된 이슈 
- resolved #28 

## 작업 내용
- 현재 로그인한 유저 가져오도록

## 논의 사항
```kotlin
	@GetMapping("/questions", produces = ["application/json"])
	fun getQuestions(@CurrentUser user: User): ResponseEntity<Any> {
		return ResponseEntity.ok().body(questionService.getQuestions())
	}
```
이런식으로 컨트롤러에서 넘기도록 하면 될 것 같습니당