### PR TITLE
♻️ refresh token DB에 저장하도록 수정

### DIFF
--- a/src/main/kotlin/com/smu/som/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/smu/som/common/config/SecurityConfig.kt
@@ -2,7 +2,6 @@ package com.smu.som.common.config
 
 import com.smu.som.common.jwt.filter.JwtAuthenticationFilter
 import com.smu.som.common.jwt.util.JwtResolver
-import com.smu.som.infra.redis.RedisService
 import org.springframework.context.annotation.Bean
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.builders.WebSecurity
@@ -14,8 +13,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 @EnableWebSecurity
 class SecurityConfig(
-	private val jwtResolver: JwtResolver,
-	private val redisService: RedisService
+	private val jwtResolver: JwtResolver
 ) {
 	@Bean
 	fun webSecurityCustomizer(): WebSecurityCustomizer? {
@@ -37,7 +35,7 @@ class SecurityConfig(
 			.antMatchers("/api/auth/signin", "/api/auth/refresh", "/api/auth/signup").permitAll()
 			.anyRequest().authenticated()
 			.and()
-			.addFilterBefore(JwtAuthenticationFilter(jwtResolver, redisService), UsernamePasswordAuthenticationFilter::class.java)
+			.addFilterBefore(JwtAuthenticationFilter(jwtResolver), UsernamePasswordAuthenticationFilter::class.java)
 		return http.build()
 	}
 }

--- a/src/main/kotlin/com/smu/som/common/entity/BaseEntity.kt
+++ b/src/main/kotlin/com/smu/som/common/entity/BaseEntity.kt
@@ -1,0 +1,21 @@
+package com.smu.som.common.entity
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.LastModifiedDate
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+import javax.persistence.Column
+import javax.persistence.EntityListeners
+import javax.persistence.MappedSuperclass
+
+@MappedSuperclass
+@EntityListeners(value = [AuditingEntityListener::class])
+abstract class BaseEntity {
+	@CreatedDate
+	@Column(name = "created_at", updatable = false)
+	var createdAt: LocalDateTime = LocalDateTime.now()
+
+	@LastModifiedDate
+	@Column(name = "updated_at")
+	var updatedAt: LocalDateTime = LocalDateTime.now()
+}

--- a/src/main/kotlin/com/smu/som/domain/user/entity/RefreshToken.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/entity/RefreshToken.kt
@@ -1,0 +1,16 @@
+package com.smu.som.domain.user.entity
+
+import com.smu.som.common.entity.BaseEntity
+import javax.persistence.*
+
+@Entity
+@Table(name = "refresh_token")
+class RefreshToken(
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	var refreshTokenId: Long? = null,
+
+	var refreshToken: String,
+
+	var oauth2Id: String
+) : BaseEntity()

--- a/src/main/kotlin/com/smu/som/domain/user/service/AuthService.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/service/AuthService.kt
@@ -1,16 +1,14 @@
 package com.smu.som.domain.user.service
 
 import com.smu.som.common.jwt.service.JwtService
-import com.smu.som.common.util.Constants.Companion.LOGOUT_ACCESS_TOKEN_PREFIX
 import com.smu.som.common.util.Constants.Companion.REFRESH_TOKEN_PREFIX
+import com.smu.som.domain.user.oauth.OAuth2ServiceFactory
 import com.smu.som.controller.error.BusinessException
 import com.smu.som.controller.error.ErrorCode
 import com.smu.som.domain.user.dto.*
 import com.smu.som.domain.user.entity.Oauth2Provider
 import com.smu.som.domain.user.entity.User
-import com.smu.som.domain.user.oauth.OAuth2ServiceFactory
-import com.smu.som.infra.redis.RedisService
-import org.springframework.beans.factory.annotation.Value
+import com.smu.som.domain.user.service.refresh.RefreshService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -20,11 +18,8 @@ class AuthService(
 	private val oAuth2ServiceFactory: OAuth2ServiceFactory,
 	private val userService: UserService,
 	private val jwtService: JwtService,
-	private val redisService: RedisService
+	private val refreshService: RefreshService
 ) {
-	@Value("\${jwt.refresh-token-expiry}")
-	private val refreshTokenExpiry: Long = 0
-
 	@Transactional
 	fun signUp(signUpRequestDTO: SignUpRequestDTO): SignUpResponseDTO {
 		val oAuth2User = oAuth2ServiceFactory
@@ -40,7 +35,7 @@ class AuthService(
 		)
 
 		val jwtToken = jwtService.issue(signUpRequestDTO.oauth2Provider, signUpRequestDTO.oauth2AccessToken)
-		storeRefreshToken(jwtToken, oAuth2User.oauth2Id)
+		refreshService.storeRefresh(jwtToken, oAuth2User.oauth2Id)
 
 		return SignUpResponseDTO(
 			jwtToken = jwtToken,
@@ -56,45 +51,25 @@ class AuthService(
 			.getOAuthService(Oauth2Provider.valueOf(signInRequestDTO.oauth2Provider.uppercase()))
 			.getOAuth2User(signInRequestDTO.oauth2AccessToken)
 
-		storeRefreshToken(jwtToken, oAuth2User.oauth2Id)
+		refreshService.storeRefresh(jwtToken, oAuth2User.oauth2Id)
 		return jwtToken
 	}
 
 	@Transactional
 	fun refresh(refreshToken: String): JwtTokenDTO {
-		val oAuth2Id = redisService.getValue("$REFRESH_TOKEN_PREFIX:${refreshToken}") as String?
+		val oAuth2Id = refreshService.getRefresh("$REFRESH_TOKEN_PREFIX:${refreshToken}")
 			?: throw BusinessException(ErrorCode.INVALID_JWT)
 
 		val user: User = userService.findByOauth2Id(oAuth2Id)
 			?: throw BusinessException(ErrorCode.USER_NOT_FOUND)
 
 		val jwtToken = jwtService.refresh(refreshToken, user.oauth2Id)
-		storeRefreshToken(jwtToken, oAuth2Id)
+		refreshService.storeRefresh(jwtToken, oAuth2Id)
 		return jwtToken
 	}
 
 	@Transactional
 	fun logout(refreshToken: String, accessToken: String) {
-		redisService.getValue("$REFRESH_TOKEN_PREFIX:$refreshToken")
-			?: throw BusinessException(ErrorCode.INVALID_REFRESH_TOKEN)
-		storeLogoutAccessToken(accessToken)
-		redisService.deleteValue("$REFRESH_TOKEN_PREFIX:$refreshToken")
-	}
-
-	private fun storeRefreshToken(jwtToken: JwtTokenDTO, oauth2Id: String) {
-		redisService.setValue(
-			"$REFRESH_TOKEN_PREFIX:${jwtToken.refreshToken}",
-			oauth2Id,
-			refreshTokenExpiry
-		)
-	}
-
-	private fun storeLogoutAccessToken(accessToken: String) {
-		val remainExpiry = jwtService.getRemainExpiry(accessToken)
-		redisService.setValue(
-			"$LOGOUT_ACCESS_TOKEN_PREFIX:${accessToken}",
-			"logout",
-			remainExpiry
-		)
+		refreshService.deleteRefresh("$REFRESH_TOKEN_PREFIX:$refreshToken")
 	}
 }

--- a/src/main/kotlin/com/smu/som/domain/user/service/refresh/RefreshService.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/service/refresh/RefreshService.kt
@@ -1,0 +1,9 @@
+package com.smu.som.domain.user.service.refresh
+
+import com.smu.som.domain.user.dto.JwtTokenDTO
+
+interface RefreshService {
+	fun storeRefresh(jwtToken: JwtTokenDTO, oauth2Id: String)
+	fun getRefresh(refreshToken: String): String?
+	fun deleteRefresh(refreshToken: String)
+}

--- a/src/main/kotlin/com/smu/som/domain/user/service/refresh/RefreshServiceDB.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/service/refresh/RefreshServiceDB.kt
@@ -1,0 +1,60 @@
+package com.smu.som.domain.user.service.refresh
+
+import com.smu.som.common.util.Constants.Companion.REFRESH_TOKEN_PREFIX
+import com.smu.som.controller.error.BusinessException
+import com.smu.som.controller.error.ErrorCode
+import com.smu.som.domain.user.dto.JwtTokenDTO
+import com.smu.som.domain.user.entity.RefreshToken
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+@Service
+@Transactional(readOnly = true)
+class RefreshServiceDB(
+	private val refreshRepository: RefreshTokenRepository
+) : RefreshService {
+
+	@Value("\${jwt.refresh-token-expiry}")
+	private val refreshTokenExpiry: Long = 0
+
+	@Transactional
+	override fun storeRefresh(jwtToken: JwtTokenDTO, oauth2Id: String) {
+		refreshRepository.deleteByOauth2Id(oauth2Id)
+		refreshRepository.save(
+			RefreshToken(
+				refreshToken = "$REFRESH_TOKEN_PREFIX:${jwtToken.refreshToken}",
+				oauth2Id = oauth2Id
+			)
+		)
+	}
+
+	@Transactional
+	override fun getRefresh(refreshToken: String): String? {
+		val findRefreshToken = refreshRepository.findByRefreshToken(refreshToken)
+			?: return null
+
+		if (!isValidate(findRefreshToken)) {
+			refreshRepository.delete(findRefreshToken)
+			return null
+		}
+		return findRefreshToken.oauth2Id
+	}
+
+	override fun deleteRefresh(refreshToken: String) {
+		val findRefreshToken = refreshRepository.findByRefreshToken(refreshToken)
+			?: throw BusinessException(ErrorCode.INVALID_REFRESH_TOKEN)
+
+		refreshRepository.delete(findRefreshToken)
+	}
+
+	private fun isValidate(refreshToken: RefreshToken): Boolean {
+		val expiryDateTime = refreshToken.createdAt.plus(refreshTokenExpiry, ChronoUnit.MILLIS)
+		if (LocalDateTime.now().isAfter(expiryDateTime)) {
+			return false
+		}
+		return true
+	}
+}

--- a/src/main/kotlin/com/smu/som/domain/user/service/refresh/RefreshServiceRedis.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/service/refresh/RefreshServiceRedis.kt
@@ -1,0 +1,53 @@
+package com.smu.som.domain.user.service.refresh
+
+import com.smu.som.common.jwt.service.JwtService
+import com.smu.som.common.util.Constants
+import com.smu.som.common.util.Constants.Companion.REFRESH_TOKEN_PREFIX
+import com.smu.som.controller.error.BusinessException
+import com.smu.som.controller.error.ErrorCode
+import com.smu.som.domain.user.dto.JwtTokenDTO
+import com.smu.som.infra.redis.RedisService
+import org.springframework.beans.factory.annotation.Value
+
+class RefreshServiceRedis(
+	private val redisService: RedisService,
+	private val jwtService: JwtService
+) : RefreshService {
+
+	@Value("\${jwt.refresh-token-expiry}")
+	private val refreshTokenExpiry: Long = 0
+
+	override fun storeRefresh(jwtToken: JwtTokenDTO, oauth2Id: String) {
+		redisService.setValue(
+			"$REFRESH_TOKEN_PREFIX:${jwtToken.refreshToken}",
+			oauth2Id,
+			refreshTokenExpiry
+		)
+	}
+
+	override fun getRefresh(refreshToken: String): String? {
+		return redisService.getValue("$REFRESH_TOKEN_PREFIX:${refreshToken}") as String?
+	}
+
+	override fun deleteRefresh(refreshToken: String) {
+		redisService.getValue("$REFRESH_TOKEN_PREFIX:${refreshToken}")
+			?: throw BusinessException(ErrorCode.INVALID_REFRESH_TOKEN)
+
+		redisService.deleteValue("$REFRESH_TOKEN_PREFIX:$refreshToken")
+	}
+
+	fun storeLogoutAccessToken(accessToken: String) {
+		val remainExpiry = jwtService.getRemainExpiry(accessToken)
+		redisService.setValue(
+			"${Constants.LOGOUT_ACCESS_TOKEN_PREFIX}:${accessToken}",
+			"logout",
+			remainExpiry
+		)
+	}
+
+	fun isLogout(accessToken: String): Boolean {
+		redisService.getValue("${Constants.LOGOUT_ACCESS_TOKEN_PREFIX}:$accessToken")
+			?: return false
+		return true
+	}
+}

--- a/src/main/kotlin/com/smu/som/domain/user/service/refresh/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/smu/som/domain/user/service/refresh/RefreshTokenRepository.kt
@@ -1,0 +1,9 @@
+package com.smu.som.domain.user.service.refresh
+
+import com.smu.som.domain.user.entity.RefreshToken
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
+	fun findByRefreshToken(refreshToken: String): RefreshToken?
+	fun deleteByOauth2Id(oauth2Id: String)
+}

--- a/src/main/kotlin/com/smu/som/infra/redis/RedisConfig.kt
+++ b/src/main/kotlin/com/smu/som/infra/redis/RedisConfig.kt
@@ -3,11 +3,13 @@ package com.smu.som.infra.redis
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.data.redis.connection.RedisConnectionFactory
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory
 import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.data.redis.serializer.StringRedisSerializer
 
+@Profile("local")
 @Configuration
 class RedisConfig(
 	@Value("\${spring.redis.host}") val redisHost: String,


### PR DESCRIPTION
## 연결된 이슈 
- resolved #39

## 작업 내용
- refresh token DB에 저장하도록 수정

## 논의 사항
- refresh token 을 따로 domain 하위 폴더로 추가를 해야하는게 괜찮을까..?
- 로그아웃한 access token을 서버에서도 처리하도록 하였는데 DB로 변경하면서 클라에서 Access token 삭제 처리 + 짧은 주기로 해결해야 할 것 같아 ! 
