### PR TITLE
:sparkles: Add get used/pass question api by user_id

### DIFF
--- a/src/main/kotlin/com/smu/som/controller/api/QuestionController.kt
+++ b/src/main/kotlin/com/smu/som/controller/api/QuestionController.kt
@@ -62,4 +62,28 @@ class QuestionController(
 			ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null)
 		}
 	}
+
+	@GetMapping("/question/{kakaoid}/used")
+	fun getUsedQuestion(
+		@PathVariable(name = "kakaoid") kakaoId: String
+	): ResponseEntity<Any> {
+		return try {
+			ResponseEntity.ok().body(questionService.getUsedQuestion(kakaoId))
+		} catch (e: Exception) {
+			e.printStackTrace()
+			ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null)
+		}
+	}
+
+	@GetMapping("/question/{kakaoid}/pass")
+	fun getPassQuestion(
+		@PathVariable(name = "kakaoid") kakaoId: String
+	): ResponseEntity<Any> {
+		return try {
+			ResponseEntity.ok().body(questionService.getPassQuestion(kakaoId))
+		} catch (e: Exception) {
+			e.printStackTrace()
+			ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null)
+		}
+	}
 }

--- a/src/main/kotlin/com/smu/som/domain/question/repository/QuestionRepository.kt
+++ b/src/main/kotlin/com/smu/som/domain/question/repository/QuestionRepository.kt
@@ -1,6 +1,7 @@
 package com.smu.som.domain.question.repository
 
 import com.smu.som.domain.question.dto.RandomQuestionDTO
+import com.smu.som.domain.question.dto.ReadQuestionDTO
 import com.smu.som.domain.question.entity.Category
 import com.smu.som.domain.question.entity.Question
 import com.smu.som.domain.question.entity.Target
@@ -12,4 +13,5 @@ interface QuestionRepository : CrudRepository<Question, Long>, QuestionRepositor
 	fun findByTargetInAndCategoryAndIsAdult(@Param("targets") targets: List<Target>, category: Category, isAdult: String): List<RandomQuestionDTO>
 	fun findByTargetIn(@Param("targets") targets: List<Target>): List<RandomQuestionDTO>
 	fun findByTargetInAndIsAdult(@Param("targets") targets: List<Target>, isAdult: String): List<RandomQuestionDTO>
+	fun findByIdIn(@Param("ids") ids: List<Long>): List<ReadQuestionDTO>
 }

--- a/src/main/kotlin/com/smu/som/domain/question/repository/UsedQuestionRepository.kt
+++ b/src/main/kotlin/com/smu/som/domain/question/repository/UsedQuestionRepository.kt
@@ -1,7 +1,12 @@
 package com.smu.som.domain.question.repository
 
+import com.smu.som.domain.question.dto.UsedQuestionDTO
 import com.smu.som.domain.question.entity.UsedQuestion
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface UsedQuestionRepository : JpaRepository<UsedQuestion, Long> {
+	fun findByUserIdAndUsedIsNotNull(userId: String): List<UsedQuestionDTO>
+	fun findByUserIdAndPassIsNotNull(userId: String): List<UsedQuestionDTO>
+	fun existsByUserId(userId: String): Boolean
+	fun deleteByUserId(userId: String)
 }

--- a/src/main/kotlin/com/smu/som/domain/question/service/QuestionService.kt
+++ b/src/main/kotlin/com/smu/som/domain/question/service/QuestionService.kt
@@ -8,7 +8,6 @@ import com.smu.som.domain.question.dto.RandomQuestionDTO
 import com.smu.som.domain.question.dto.ReadQuestionDTO
 import com.smu.som.domain.question.dto.UsedQuestionDTO
 import com.smu.som.domain.question.entity.Category
-import com.smu.som.domain.question.entity.Question
 import com.smu.som.domain.question.entity.Target
 import com.smu.som.domain.question.repository.QuestionRepository
 import com.smu.som.domain.question.repository.UsedQuestionRepository
@@ -93,6 +92,9 @@ class QuestionService(
 	@Transactional
 	fun addQuestionInMyPage(kakaoId: String, getUsedQuestionDTO: GetUsedQuestionDTO): Boolean {
 		try {
+			if(usedQuestionRepository.existsByUserId(kakaoId)){
+				usedQuestionRepository.deleteByUserId(kakaoId)
+			}
 			for (i: Long in getUsedQuestionDTO.used)
 				usedQuestionRepository.save(UsedQuestionDTO(kakaoId, i, null).toEntity())
 			for (i: Long in getUsedQuestionDTO.pass)
@@ -102,5 +104,21 @@ class QuestionService(
 			return false
 		}
 		return true
+	}
+
+	fun getUsedQuestion(kakaoId: String): List<ReadQuestionDTO> {
+		val usedQuestion = usedQuestionRepository.findByUserIdAndUsedIsNotNull(kakaoId)
+		var ids: ArrayList<Long> = arrayListOf()
+		for(i: UsedQuestionDTO in usedQuestion)
+			i.used?.let { ids.add(it) }
+		return questionRepository.findByIdIn(ids)
+	}
+
+	fun getPassQuestion(kakaoId: String): List<ReadQuestionDTO> {
+		val passQuestion = usedQuestionRepository.findByUserIdAndPassIsNotNull(kakaoId)
+		var ids: ArrayList<Long> = arrayListOf()
+		for(i: UsedQuestionDTO in passQuestion)
+			i.pass?.let { ids.add(it) }
+		return questionRepository.findByIdIn(ids)
 	}
 }


### PR DESCRIPTION
## 연결된 이슈 
- resolved #67

## 작업 내용
- get pass/used question by user_id 관련 api 2개 추가

## 논의 사항
- 이게 최종적으로 완료한 버전입니다..! 확인하구 comment 남겨주세요..
- 우선 기존에 현민님과 디자인한 api가
question/{kakaoid}/{target}/used(pass) 였는데 현재 제작한 api는 question/{kakaoid}/used(pass)입니다.
사유 : 유형별(부부, 연인, 부모자녀) 질문한 내용, 패스한 내용을 교수님께서 출력하라고하심
-> 의문 : 각 게임은 유형별(부부, 연인, 부모자녀)로 나뉘어 게임을 진행하게 되는데 예를 들어, 부부로 한 게임을 진행한 후 연인으로 진행하면 부부로 플레이한 관련 내역은 사라지고 연인만 자연스레 남게 될텐데 따로 target을 지정하는 이유

  이 부분에 대해서는 답장오면 바로 공유할게..! 그럼 api를 수정해야 할 수도 있어서
- 따로 프론트는 잘 작동되어서 수정할 필요가 없을 것 같습니다..!
- 제가 개발 초보라.. git이 익숙하지 않아 그만 실수를 해버렸슴당...이미 닫힌 PR도 한번만 확인해쥬시면 감사하겠습니다..
