### PR TITLE
:wrench: 게임횟수 출력 api 작성 & 게임횟수 저장 기능 추가

### DIFF
--- a/src/main/kotlin/com/smu/som/controller/api/QuestionController.kt
+++ b/src/main/kotlin/com/smu/som/controller/api/QuestionController.kt
@@ -53,9 +53,11 @@ class QuestionController(
 	@PostMapping("/question/{kakaoid}/{target}")
 	fun myQuestion(
 		@PathVariable(name = "kakaoid") kakaoId: String,
+		@PathVariable(name = "target") target: String,
 		@RequestBody getUsedQuestionDTO: GetUsedQuestionDTO
 	): ResponseEntity<Any> {
 		return try {
+			questionService.increasePlayCount(kakaoId, Target.valueOf(target.uppercase()))
 			ResponseEntity.ok().body(questionService.addQuestionInMyPage(kakaoId, getUsedQuestionDTO))
 		} catch (e: Exception) {
 			e.printStackTrace()
@@ -87,5 +89,12 @@ class QuestionController(
 			e.printStackTrace()
 			ResponseEntity.status(HttpStatus.BAD_REQUEST).body(null)
 		}
+	}
+
+	@GetMapping("/question/playcount/{kakaoid}")
+	fun getPlayCount(
+		@PathVariable(name = "kakaoid") kakaoId: String
+	): ResponseEntity<Any> {
+		return ResponseEntity.ok().body(questionService.getPlayCount(kakaoId))
 	}
 }

--- a/src/main/kotlin/com/smu/som/domain/question/dto/PlayCountDTO.kt
+++ b/src/main/kotlin/com/smu/som/domain/question/dto/PlayCountDTO.kt
@@ -1,0 +1,27 @@
+package com.smu.som.domain.question.dto
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.smu.som.domain.question.entity.PlayCount
+
+class PlayCountDTO(
+	@JsonProperty("userId")
+	var userId: String,
+
+	@JsonProperty("couple")
+	var couple: Long = 0,
+
+	@JsonProperty("married")
+	var married: Long = 0,
+
+	@JsonProperty("family")
+	var family: Long = 0
+) {
+	fun toEntity(): PlayCount{
+		return PlayCount(
+			userId = userId,
+			couple = couple,
+			married = married,
+			family = family
+		)
+	}
+}

--- a/src/main/kotlin/com/smu/som/domain/question/entity/PlayCount.kt
+++ b/src/main/kotlin/com/smu/som/domain/question/entity/PlayCount.kt
@@ -1,16 +1,19 @@
 package com.smu.som.domain.question.entity
 
+import com.smu.som.domain.question.dto.PlayCountDTO
 import javax.persistence.*
 
 @Entity
-@Table(name = "used_question")
-class UsedQuestion(
+@Table(name = "play_count")
+class PlayCount(
 	@Id @GeneratedValue(strategy = GenerationType.IDENTITY)
 	val id: Long = 0,
 
 	var userId: String,
 
-	var used: Long?,
+	var couple: Long?,
 
-	var pass: Long?
+	var married: Long?,
+
+	var family: Long?
 )

--- a/src/main/kotlin/com/smu/som/domain/question/repository/PlayCountRepository.kt
+++ b/src/main/kotlin/com/smu/som/domain/question/repository/PlayCountRepository.kt
@@ -1,0 +1,11 @@
+package com.smu.som.domain.question.repository
+
+import com.smu.som.domain.question.dto.PlayCountDTO
+import com.smu.som.domain.question.entity.PlayCount
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PlayCountRepository : JpaRepository<PlayCount, Long> {
+	fun existsByUserId(userId: String): Boolean
+	fun findByUserId(userId: String): PlayCountDTO
+	fun deleteByUserId(userId: String)
+}


### PR DESCRIPTION
## 연결된 이슈 
- resolved #70 

## 작업 내용
- 게임횟수 출력 api 작성
- 게임횟수 저장용 DB 생성

## 논의 사항
- ![image](https://user-images.githubusercontent.com/19797395/210280582-a0ae2072-3ea6-40ce-953f-16b719947091.png)
- DB에 저장된 값
- ![image](https://user-images.githubusercontent.com/19797395/210280706-dc056322-ac79-4fb5-831a-43b90d6b6875.png)
- test 결과(질문은 아무 숫자나 넣었는데 이케되어버렸네 쩝..)
***
- 테스트 해본 결과 DB상에 중복으로 들어있더라도 id가 고유한 값이라 가져오면 자동으로 중복이 안되는거 같어!
- 추가적으로, 이제 각 유저별 게임 count를 넣었으니, 기존에 보유한 used/pass 질문 table을 한번 비워야 할 거 같아서 이건 현민님이 ㅇㅋ 하시면 DB에서 내가 truncate로 날릴게! 
- 배포 잘부탁해용..
